### PR TITLE
Add ESP32-S3 USB HID sketch to run taskkill for notepad

### DIFF
--- a/notepad-killer-esp32s3.ino
+++ b/notepad-killer-esp32s3.ino
@@ -1,0 +1,45 @@
+/*
+  Geekble Nano ESP32-S3 (USB HID Keyboard)
+  Opens Win+R and runs taskkill for notepad.
+
+  For authorized testing environments only.
+*/
+
+#include "USB.h"
+#include "USBHIDKeyboard.h"
+
+USBHIDKeyboard Keyboard;
+
+bool sent = false;
+
+void sendTaskkillNotepad() {
+  // Win + R
+  Keyboard.press(KEY_LEFT_GUI);
+  Keyboard.press('r');
+  delay(80);
+  Keyboard.releaseAll();
+  delay(300);
+
+  // Run command
+  Keyboard.print("cmd /c taskkill /IM notepad.exe /F");
+  delay(80);
+
+  // Enter
+  Keyboard.write(KEY_RETURN);
+}
+
+void setup() {
+  USB.begin();
+  Keyboard.begin();
+
+  delay(1500); // wait for host recognition
+
+  if (!sent) {
+    sendTaskkillNotepad();
+    sent = true;
+  }
+}
+
+void loop() {
+  delay(1000);
+}


### PR DESCRIPTION
### Motivation
- Provide a simple USB HID keyboard sketch for the Geekble Nano ESP32-S3 that opens the Windows Run dialog and executes a `taskkill` command to terminate `notepad.exe` for authorized testing.
- Include an explicit caution by design to restrict usage to authorized testing environments only.

### Description
- Add new file `notepad-killer-esp32s3.ino` which initializes `USB` and `USBHIDKeyboard` and waits for host recognition before sending input.
- Implement `sendTaskkillNotepad()` to press `KEY_LEFT_GUI`+`r`, type `cmd /c taskkill /IM notepad.exe /F`, and send `KEY_RETURN`, and ensure it runs only once via a `sent` flag.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2562ebe2c8326b0c168421b3ad2e8)